### PR TITLE
Fix two alerts from lgtm.com: unintentional use of bitwise logical OR

### DIFF
--- a/core/carrot2-util-xsltfilter/src/org/carrot2/util/xsltfilter/XSLTFilterServletResponse.java
+++ b/core/carrot2-util-xsltfilter/src/org/carrot2/util/xsltfilter/XSLTFilterServletResponse.java
@@ -154,7 +154,7 @@ final class XSLTFilterServletResponse extends HttpServletResponseWrapper
     private boolean processingSuppressed(HttpServletRequest origRequest2)
     {
         return (origRequest.getAttribute(XSLTFilterConstants.NO_XSLT_PROCESSING) != null)
-            | (origRequest.getParameter(XSLTFilterConstants.NO_XSLT_PROCESSING) != null);
+            || (origRequest.getParameter(XSLTFilterConstants.NO_XSLT_PROCESSING) != null);
     }
 
     /**
@@ -279,7 +279,7 @@ final class XSLTFilterServletResponse extends HttpServletResponseWrapper
                 final byte [] bytes = ((DeferredOutputStream) stream).getBytes();
                 final boolean processingSuppressed = (origRequest
                     .getAttribute(XSLTFilterConstants.NO_XSLT_PROCESSING) != null)
-                    | (origRequest.getParameter(XSLTFilterConstants.NO_XSLT_PROCESSING) != null);
+                    || (origRequest.getParameter(XSLTFilterConstants.NO_XSLT_PROCESSING) != null);
 
                 if (processingSuppressed)
                 {


### PR DESCRIPTION
Fix two alerts reported by lgtm.com: use of bitwise logical OR (rather than conditional-or) was probably unintentional.

More details:
https://lgtm.com/projects/g/carrot2/carrot2/snapshot/dist-1792920537-1490802114895/files/core/carrot2-util-xsltfilter/src/org/carrot2/util/xsltfilter/XSLTFilterServletResponse.java#L157

lgtm.com reports a total of 23 alerts, including a number of potential resource leaks - definitely worth looking into, but harder for me to do without more knowledge about the code.

Tip: if you enable pull request integration you get automated code review in your PRs!  