### PR TITLE
Ignore unknown properties from json in Bing Response

### DIFF
--- a/core/carrot2-source-microsoft/src/org/carrot2/source/microsoft/v5/UnstructuredResponse.java
+++ b/core/carrot2-source-microsoft/src/org/carrot2/source/microsoft/v5/UnstructuredResponse.java
@@ -14,6 +14,7 @@ package org.carrot2.source.microsoft.v5;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 class UnstructuredResponse extends BingResponse {
   @JsonProperty(required = true)
   public int statusCode;


### PR DESCRIPTION
It fix this exception when working with Bing API by adding `@JsonIgnoreProperties(ignoreUnknown = true)` annotation:
```java
org.carrot2.core.ProcessingException: Unrecognized field "activityId" (class org.carrot2.source.microsoft.v5.UnstructuredResponse), not marked as ign
orable (2 known properties: "statusCode", "message"])
```